### PR TITLE
Fixes for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ set(PROJECT_DESCRIPTION "POD game archive format library written in C for all ex
 include(GNUInstallDirs)
 include(FindPkgConfig)
 
+if(MSYS AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+set(CMAKE_INSTALL_PREFIX $ENV{MINGW_PREFIX} CACHE PATH $ENV{MINGW_PREFIX} FORCE)
+endif()
+
+if(WIN32)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+else()
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+endif()
+
 set(SOURCE_FILES
 	src/path.c
 	src/mkdir_p.c
@@ -44,7 +54,7 @@ pkg_search_module(ZIP REQUIRED libzip)
 pkg_search_module(CRC REQUIRED libcrc)
 
 # libpodfmt library
-add_library( ${PROJECT_NAME} SHARED ${SOURCE_FILES} ${INCLUDE_FILES}
+add_library( ${PROJECT_NAME} ${SOURCE_FILES} ${INCLUDE_FILES}
 	${CRC_INCLUDE} ${ZIP_INCLUDE})
 target_compile_options( ${PROJECT_NAME} PUBLIC ${CRC_CFLAGS} ${ZIP_CFLAGS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CRC_INCLUDEDIR} ${ZIP_INCLUDEDIR}
@@ -72,4 +82,4 @@ install(TARGETS podfmt EXPORT ${PROJECT_NAME}Config
 install(FILES ${INCLUDE_FILES} DESTINATION
 	${CMAKE_INSTALL_INCLUDEDIR}/lib${PROJECT_NAME}/)
 
-install(FILES lib${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+install(FILES ${PROJECT_BINARY_DIR}/lib${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)

--- a/src/mkdir_p.c
+++ b/src/mkdir_p.c
@@ -3,6 +3,13 @@ http://nion.modprobe.de/blog/archives/357-Recursive-directory-creation.html
 */
 #include "path.h"
 #include "mkdir_p.h"
+
+#ifdef _WIN32
+const char dirsep = '\\';
+#else
+const char dirsep = '/';
+#endif
+
 /* recursive mkdir */
 int mkdir_p(const char *pathname, const mode_t mode) 
 {
@@ -20,7 +27,7 @@ int mkdir_p(const char *pathname, const mode_t mode)
     tmp[len] = '\0';
 
     /* remove trailing slash */
-    if(tmp[len - 1] == '/') {
+    if(tmp[len - 1] == dirsep) {
         tmp[len - 1] = '\0';
     }
 
@@ -33,26 +40,34 @@ int mkdir_p(const char *pathname, const mode_t mode)
     
     /* recursive mkdir */
     for(p = tmp + 1; *p; p++) {
-        if(*p == '/') {
+        if(*p == dirsep) {
             *p = 0;
             /* test path */
             if (stat(tmp, &sb) != 0) {
                 /* path does not exist - create directory */
-                if (mkdir(tmp, mode) < 0) {
+#ifdef _WIN32
+				if (mkdir(tmp) < 0) {
+#else
+				if (mkdir(tmp, mode) < 0) {
+#endif
                     return -1;
                 }
             } else if (!S_ISDIR(sb.st_mode)) {
                 /* not a directory */
                 return -1;
             }
-            *p = '/';
+            *p = dirsep;
         }
     }
     /* test path */
     if (stat(tmp, &sb) != 0) 
     {
         /* path does not exist - create directory */
+#ifdef _WIN32
+        if (mkdir(tmp) < 0)
+#else
         if (mkdir(tmp, mode) < 0)
+#endif
 	{
             return -1;
         }

--- a/src/pod_common.h
+++ b/src/pod_common.h
@@ -8,10 +8,17 @@
 #define __USE_GNU 1
 #endif
 #ifdef __WIN32__
-#ifdef __MSYS__
+#ifdef __CYGWIN__
 #include <sys/cygwin.h>
-#elif defined __CYGWIN__
-#include <sys/cygwin.h>
+#endif
+#ifndef ACCESSPERMS
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO) /* 0777 */
+#endif
+#ifndef reallocarray
+#define reallocarray(ptr, nmemb, size) realloc(ptr, (nmemb) * (size))
+#endif
+#ifndef realpath
+#define realpath(path, resolved_path) _fullpath(resolved_path, path, PATH_MAX)
 #endif
 #endif
 #include <string.h>


### PR DESCRIPTION
1.  Set `CMAKE_INSTALL_PREFIX` to `MINGW_PREFIX` on MSYS2
2.  Option to build shared or static library.
3.  Fixes for Windows\*

\*Admittedly, this is a very dirty fix, but I just wanted to quickly try out `podorgana`.  It should be possible to create the directory structure in an easier (and portable) way. In the meantime, everything builds and runs in MSYS2 with all 3 PRs I sent your way.